### PR TITLE
Fix race condition with 2 stripe customers for 1 user

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ export async function GET(req: Request) {
       email: user.email,
       metadata: {
         userId: user.id, // DO NOT FORGET THIS
-      },
+      }
+    }, {
+        // prevent race conditions of creating 2 customers in stripe for on user
+        // https://github.com/stripe/stripe-node/issues/476#issuecomment-402541143
+        idempotencyKey: user.id
     });
 
     // Store the relation between userId and stripeCustomerId in your KV


### PR DESCRIPTION
In the originally provided code snippet for creating a stripe customer there's a race condition when you can create 2 customers for 1 user.

This is due to the fact that the check if the customer already exists is conducted on your server, which gets this data asynchronously. As a result your server might think that the customer does not exist, but in reality it was just created. Even if calling stripe api to determine this instead of relying on your own data will have this issue because you can get the response that "the customer does not exist", but while this response is coming to your server, the customer was already created.

There are only 2 solutions to this problem:
1) (❌ doesn't exist) Have stripe provide you an atomic getOrCreateCustomer({ userId }) operation 
2) (✅ exists) Provide an idempotency key to the createCustomer operation. This is explained here - https://github.com/stripe/stripe-node/issues/476#issuecomment-402541143